### PR TITLE
Add gg.cmd

### DIFF
--- a/Config/Tasks/BuiltIn/Download-gg.cmd.json
+++ b/Config/Tasks/BuiltIn/Download-gg.cmd.json
@@ -1,0 +1,6 @@
+{
+    "id": "gg.cmd",
+    "name": "[Download] gg.cmd",
+    "type": "config",
+    "script": "Download-gg.cmd.ps1"
+}

--- a/Config/Tasks/BuiltIn/Download-gg.cmd.ps1
+++ b/Config/Tasks/BuiltIn/Download-gg.cmd.ps1
@@ -1,0 +1,34 @@
+param(
+  [Parameter()]
+  [string]$Action,
+  [Parameter()]
+  [bool]$ForceCache,
+  [Parameter()]
+  [object]$Vars
+)
+
+$OutPath = "$CSCachePath\gg.cmd"
+
+switch ($Action) {
+  "cache" {
+    if (!$ForceCache -and (Test-Path $OutPath)) { break; }
+
+    $DownloadURL = "https://github.com/eirikb/gg/releases/latest/download/gg.cmd"
+    Invoke-WebRequest -Uri $DownloadURL -OutFile $OutPath -UseBasicParsing
+
+    break;
+  }
+
+  "execute" {
+    if (Test-Path $OutPath) {
+      Copy-Item -Path $OutPath -Destination "$HOME\gg.cmd"
+    } else {
+      Write-Host "Utility not found for task $($MyInvocation.MyCommand.Name)"
+    }
+    break;
+  }
+
+  default {
+    Write-Host "Unknown action ($Action) on $($MyInvocation.MyCommand.Name)"
+  }
+}


### PR DESCRIPTION
[`gg.cmd`](https://github.com/eirikb/gg) is a cross-platform and cross-architecture command-line interface (CLI) that acts as an executable wrapper for various tools such as Gradle, JDK/JVM, Node.js, and Java.

`gg.cmd` just runs on Windows (and macOS and Linux) and downloads dependencies on demand.

Example:

    .\gg.cmd jbang git@jbangdev --help

This downloads a JDK, jbang and executes the `git` variant implemented in Java.

I think, this is super-cool and should be made available as default in CustomSandbox.